### PR TITLE
Fix downloading of books whose title has trailing whitespace

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -48,7 +48,7 @@ function replacePathChars(path) {
 }
 
 function pushQueueItem(filename, url) {
-    var path = replacePathChars(parsedContent.author + ' - ' + parsedContent.title);
+    var path = (replacePathChars(parsedContent.author + ' - ' + parsedContent.title)).trim();
     var fileRelativePath = path + "/" + filename;
     queue.push({url: url, filename: fileRelativePath, conflictAction: 'overwrite'});
 }

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -48,7 +48,7 @@ function replacePathChars(path) {
 }
 
 function pushQueueItem(filename, url) {
-    var path = (replacePathChars(parsedContent.author + ' - ' + parsedContent.title)).trim();
+    var path = replacePathChars(parsedContent.author + ' - ' + parsedContent.title);
     var fileRelativePath = path + "/" + filename;
     queue.push({url: url, filename: fileRelativePath, conflictAction: 'overwrite'});
 }

--- a/extension/js/content/parser.js
+++ b/extension/js/content/parser.js
@@ -76,8 +76,8 @@ function preparePageData(response) {
 
     const data = {
         id: bookId,
-        author: response.author,
-        title: response.titleonly,
+        author: response.author.trim(),
+        title: response.titleonly.trim(),
         description: getDescriptionText(),
         metadata: getMetaData(),
         image: getBookCover(),

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_appName__",
     "description": "__MSG_appDesc__",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "manifest_version": 2,
     "default_locale": "ru",
     "author": "PhoenixRVD",


### PR DESCRIPTION
This fixes the "Unchecked lastError value: Error: filename must not
contain illegal characters" error while trying to download an audiobook
whose title has a space at the end
(https://akniga.org/valeriya-volchya-semya-bruts). The generated
filenames had the following pattern:

```
Волчья Валерия - Семья Брутс /cover.jpg
Волчья Валерия - Семья Брутс /desc.txt
```

which are fine (verified in OS X 10.14.6), but Firefox 84.0.2 complained
about them.

~~The fix is to trim `path` after it's constructed from the `author` and
`title` strings so that it doesn't have leading or trailing whitespace.~~

Update: The fix is to trim author and title rather than the download directory.
This is done in the parser and also fixes a possible case with
leading/trailing whitespace, which could result in the following
undesirable path: `Author    -    Title/cover.jpg`. This commit removes
trimming of the download directory because that is no longer necessary
with the cleaned up parsed data.

