### PR TITLE
Fix downloading single-file audiobooks

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -48,7 +48,13 @@ function replacePathChars(path) {
 }
 
 function pushQueueItem(filename, url) {
-    var path = replacePathChars(parsedContent.author + ' - ' + parsedContent.title);
+    const rawDirectory = parsedContent.author != ''
+        ? parsedContent.author + ' - ' + parsedContent.title
+        // firefox 108.0.1 doesn't want to download any file when the directory starts
+        // with ` - ` in case `author` is empty, so we're using only the `title` in
+        // such cases; for example, https://akniga.org/zolotoy-fond-radiospektakley-chast-1-sbornik-audiospektakley
+        : parsedContent.title;
+    var path = replacePathChars(rawDirectory);
     var fileRelativePath = path + "/" + filename;
     queue.push({url: url, filename: fileRelativePath, conflictAction: 'overwrite'});
 }

--- a/extension/js/content/parser.js
+++ b/extension/js/content/parser.js
@@ -43,15 +43,23 @@ function getBookCover() {
 
 function getURLs(bookId, data) {
     const baseURL = `${data.srv}b/${bookId}/${data.key}/`;
-    return data.items
-        .map(item => item.file)
-        .nub()
-        .map(file => {
-            // note: filenames have a two-digit one-based index
-            // a long book to see the URLs is: https://akniga.org/tolstoy-lev-voyna-i-mir-1
-            const index = file.toString().padStart(2, '0');
-            return `${baseURL}${index}. ${data.title}.mp3`
-        })
+
+    const newURLFormat = data.slug != null;
+
+    return newURLFormat
+        // even some long books use this new, single-file format now,
+        // for example: 58 hours — https://akniga.org/tolstoy-lev-voyna-i-mir-1
+        ? [`${baseURL}${data.slug}.mp3`]
+        // but some longer books use the old, multi-file format,
+        // for example: 92.5 hours — https://akniga.org/zolotoy-fond-radiospektakley-chast-1-sbornik-audiospektakley
+        : data.items
+            .map(item => item.file)
+            .nub()
+            .map(file => {
+                // note: filenames have a two-digit one-based index
+                const index = file.toString().padStart(2, '0');
+                return `${baseURL}${index}. ${data.title}.mp3`
+            })
 }
 
 // Removes sequentially-duplicated values leaving only the first from each group.


### PR DESCRIPTION
Some (most?) audiobooks, even long ones, now use a new, single-file URL
format where the filename is the "slug" (which is also the book's name
in the page URL) instead of the indexed book title.

Also:
* Work around firefox not downloading any file if there is no author

    That case produced filenames like ` - title/file.mp3`, which were
ignored by firefox 108.0.1 for some reason. The fix is to use only
`title` if the `author` is empty.