### PR TITLE
Fix downloading of newer books

### DIFF
--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -44,7 +44,7 @@ function watchQueuedItems() {
 }
 
 function replacePathChars(path) {
-    return path.replace(/[~!@#$%^&*()_|+=?;:'",<>\{\}\[\]\\\/`]/g, "_");
+    return path.replace(/[~!@#$%^&*()_|+=?;:'"<>\{\}\[\]\\\/`]/g, "_");
 }
 
 function pushQueueItem(filename, url) {

--- a/extension/js/background.js
+++ b/extension/js/background.js
@@ -86,7 +86,7 @@ function downloadContent() {
 
     // Add all MP3 Tracks
     for (const trackUrl of parsedContent.files) {
-        var filename = replacePathChars(trackUrl.basename());
+        var filename = replacePathChars(new URL(trackUrl).basename());
         pushQueueItem(filename, trackUrl);
     }
 
@@ -94,10 +94,11 @@ function downloadContent() {
     watchQueuedItems();
 }
 
-// Returns the filename or directory portion of pathname.
-// E.g. `"foo/bar.baz".basename() == "bar.baz"`, `"foobar".basename() == "foobar"`.
-String.prototype.basename = function() {
-    return this.substr(this.lastIndexOf('/') + 1);
+// Returns the filename portion (the string after the last `/`) of URL's pathname.
+// E.g. `new URL('https://example.org/b/foo/bar.baz.mp3?param=yes').basename() == "bar.baz.mp3"`
+URL.prototype.basename = function() {
+    const path = this.pathname;
+    return path.substr(path.lastIndexOf('/') + 1);
 }
 
 function buttonDisable(tabId) {

--- a/extension/js/content/parser.js
+++ b/extension/js/content/parser.js
@@ -62,8 +62,10 @@ function getURLs(bookId, data) {
     const newURLFormat = data.slug != null;
 
     return newURLFormat
-        // even some long books use this new, single-file format now,
-        // for example: 58 hours — https://akniga.org/tolstoy-lev-voyna-i-mir-1
+        // this previous "new URL format" seems to be broken because there is no
+        // `key` even if there is `slug`
+        // (previous example: 58 hours — https://akniga.org/tolstoy-lev-voyna-i-mir-1
+        // now uses the `res` value above)
         ? [`${baseURL}${data.slug}.mp3`]
         // but some longer books use the old, multi-file format,
         // for example: 92.5 hours — https://akniga.org/zolotoy-fond-radiospektakley-chast-1-sbornik-audiospektakley

--- a/extension/js/content/parser.js
+++ b/extension/js/content/parser.js
@@ -12,14 +12,16 @@ function loadBookData(onSuccess) {
     });
 }
 
+// the encryption key is taken from the webpage's js file and seems to be static
+const encryptionKey = 'EKxtcg46V';
+
 // Makes an AJAX request to get information about the book with `bookId`.
 // `onSuccess` is called if the request has succeeded, its parameter is parsed JSON response.
 function requestBookData(bookId, onSuccess) {
     // note: `LIVESTREET_SECURITY_KEY` is set in the HTML page and it's correlated with the user's cookie
     // the request below works because the browser sends the user's cookie along with our data
     const securityKey = retrieveWindowVariables(['LIVESTREET_SECURITY_KEY']).LIVESTREET_SECURITY_KEY;
-    // the encryption key is taken from the webpage's js file and seems to be static
-    const encryptedHash = CryptoJS.AES.encrypt(JSON.stringify(securityKey), 'EKxtcg46V', { format:JsonFormatter }).toString();
+    const encryptedHash = CryptoJS.AES.encrypt(JSON.stringify(securityKey), encryptionKey, { format:JsonFormatter }).toString();
 
     $.post('https://akniga.org/ajax/b/' + bookId,
         { bid: bookId, hash: encryptedHash, security_ls_key: securityKey },
@@ -42,6 +44,19 @@ function getBookCover() {
 }
 
 function getURLs(bookId, data) {
+    // now (most?) books use this newer way of getting the URL
+    // for example: https://akniga.org/azimov-ayzek-mesto-gde-mnogo-vody-3
+    if (data.res) {
+      // this is adapted from the website's javascript code
+      const fileVersion = data.version > 1 ? `&v=${data.version}` : '';
+      // `JSON.parse` is needed because the encrypted url is json-encoded
+      // (wrapped in quotes and contains escaped slashes)
+      const fileURL = JSON.parse(
+          CryptoJS.AES.decrypt(data.res, encryptionKey, { format: JsonFormatter }).toString(CryptoJS.enc.Utf8)
+      ) + fileVersion;
+      return [fileURL];
+    }
+
     const baseURL = `${data.srv}b/${bookId}/${data.key}/`;
 
     const newURLFormat = data.slug != null;


### PR DESCRIPTION
The newer way of getting the audiobook's URL is to decrypt the `res` value in the response if present. The previous "new URL format" seems to be broken because there is no `key` even if there is `slug` in the response.

The filenames for new URLs are cleaned up. The previous `String.basename` implementation produces filenames like `azimov-ayzek-mesto-gde-mnogo-vody-3.mp3_res_hYOpc4-sXCpE8_5fE7ceQQ_expires_1698858605` (with URL query parameters at the end). The new `URL.basename` implementation drops the query parameters producing normal filenames like `azimov-ayzek-mesto-gde-mnogo-vody-3.mp3`.

Also:
* Allow commas in filenames

  For example, https://akniga.org/azimov-ayzek-mesto-gde-mnogo-vody-3
would generate the directory name `Азимов Айзек - Место_ где много
воды`, whereas now it generates `Азимов Айзек - Место, где много воды`.
A comma isn't a special character in filenames.